### PR TITLE
include_diagonals for higher dimensions 

### DIFF
--- a/board.py
+++ b/board.py
@@ -568,13 +568,14 @@ class Board(object):
         For a given coordinate, yield each of its nearest neighbours along
         all dimensions, including diagonal neighbours if requested (the default)
         """
-        # fliter out the tuple(0,0,0...,0) offset.  This is the center and is not considered a neighbour
-        offsets = (o for o in itertools.product(*[(-1, 0, 1) for d in self.dimensions])
-                   if not all(dim == 0 for dim in o) )
+        offsets = itertools.product(*[(-1, 0, 1) for d in self.dimensions])
         for offset in offsets:
-            # Diagonal offsets have no zero component
+            if all(o == 0 for o in offset):
+                continue
             #
-            if include_diagonals or any(o == 0 for o in offset):
+            # Diagonal offsets change in more than one dimension.
+            #
+            if include_diagonals or sum(abs(o) for o in offset) == 1:
                 neighbour = tuple(c + o for (c, o) in zip(coord, offset))
                 if self._is_in_bounds(neighbour):
                     yield neighbour

--- a/board.py
+++ b/board.py
@@ -568,11 +568,10 @@ class Board(object):
         For a given coordinate, yield each of its nearest neighbours along
         all dimensions, including diagonal neighbours if requested (the default)
         """
-        offsets = itertools.product(*[(-1, 0, 1) for d in self.dimensions])
+        # fliter out the tuple(0,0,0...,0) offset.  This is the center and is not considered a neighbour
+        offsets = (o for o in itertools.product(*[(-1, 0, 1) for d in self.dimensions])
+                   if not all(dim == 0 for dim in o) )
         for offset in offsets:
-            if all(o == 0 for o in offsets):
-                continue
-            #
             # Diagonal offsets have no zero component
             #
             if include_diagonals or any(o == 0 for o in offset):

--- a/test.py
+++ b/test.py
@@ -787,6 +787,23 @@ class BoardNeighbours(BoardTest):
 
     Neighbours should show all immediately adjacent coordinates which are on the board
     """
+    def test_neighbours_1d_center(self):
+        """
+        Really small 1 dimension board still has neighbours.
+        """
+        b = Board(dimension_sizes=(3,))
+        coord = (1,)
+        expected = {(0,), (2,)}
+        actual = set(b.neighbours(coord))
+        self.assertEqual(expected, actual)
+
+    def test_neighbours_1d_center_no_diagonals(self):
+        b = Board(dimension_sizes=(3,))
+        coord = (1,)
+        expected = {(0,), (2,)}
+        actual = set(b.neighbours(coord, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
     def test_neighbours_2d_corner(self):
         """Find neighbours when the anchor is at the corner of a 2d board
         """
@@ -795,6 +812,16 @@ class BoardNeighbours(BoardTest):
         coord = (0, 0)
         expected = {(1, 0), (0, 1), (1, 1)}
         actual = set(b.neighbours(coord))
+        self.assertEqual(expected, actual)
+
+    def test_neighbours_2d_corner_exclude_diagonals(self):
+        """Find neighbours when the anchor is at the corner of a 2d board
+        """
+        b = self.b44
+
+        coord = (0, 0)
+        expected = {(1, 0), (0, 1)}
+        actual = set(b.neighbours(coord, include_diagonals=False))
         self.assertEqual(expected, actual)
 
     def test_neighbours_2d_centre(self):
@@ -811,6 +838,20 @@ class BoardNeighbours(BoardTest):
         actual = set(b.neighbours((1, 1)))
         self.assertEqual(expected, actual)
 
+    def test_neighbours_2d_centre_exclude_diagonals(self):
+        """Find neighbours when the anchor is not at the corner of a 2d board
+        """
+        b = self.b44
+
+        coord = (1, 1)
+        expected = {
+                    (1, 0),
+            (0, 1),         (2, 1),
+                    (1, 2)
+        }
+        actual = set(b.neighbours((1, 1), include_diagonals=False))
+        self.assertEqual(expected, actual)
+
     def test_neighbours_3d_corner(self):
         """Find neighbours when the anchor is at the corner of a 3d board
         """
@@ -821,6 +862,18 @@ class BoardNeighbours(BoardTest):
             (0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)
         }
         actual = set(b.neighbours(coord))
+        self.assertEqual(expected, actual)
+
+    def test_neighbours_3d_corner_exclude_diagonals(self):
+        """Find neighbours when the anchor is at the corner of a 3d board
+        """
+        b = self.b333
+
+        coord = (0, 0, 0)
+        expected = {
+            (0, 0, 1), (0, 1, 0), (1, 0, 0)
+        }
+        actual = set(b.neighbours(coord, include_diagonals=False))
         self.assertEqual(expected, actual)
 
     def test_neighbours_3d_centre(self):
@@ -839,6 +892,24 @@ class BoardNeighbours(BoardTest):
         actual = set(b.neighbours((1, 1, 1)))
         self.assertEqual(expected, actual)
 
+    def test_neighbours_3d_centre_exclude_diagonals(self):
+        """Find neighbours when the anchor is not at the corner of a 3d board
+        """
+        b = self.b333
+
+        x, y, z = (1, 1, 1)
+        expected = set()
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                for dz in (-1, 0, 1):
+                    offset = (dx, dy, dz)
+                    # exclude the origin offset (0,0,0).
+                    # exclude any offset where more than one dimension changes (diagonal)
+                    if offset != (0, 0, 0) and sum(abs(o) for o in offset) == 1:
+                        expected.add((x + dx, y + dy, z + dz))
+
+        actual = set(b.neighbours((1, 1, 1), include_diagonals=False))
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_neighbour_board.py
+++ b/test_neighbour_board.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+import board
+
+class TestBoard(TestCase):
+    def test_neighbours_original(self):
+        b1 = board.Board((3, 3, 3))
+        neighbours = list(b1.neighbours((0, 0, 0), include_diagonals=False))
+
+        for coord in neighbours:
+            print(coord)
+        self.assertEqual(3, len(neighbours))
+
+
+        neighbours = list(b1.neighbours((0,0,0), include_diagonals=True))
+        self.assertEqual(7, len(neighbours))
+
+    def test_two_by_two_board_neighbours(self):
+        b = board.Board((2, 2))
+        target_coord = (0,0)
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=True))
+        self.assertEqual(3, len(neighbour_coord))
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=False))
+        self.assertEqual(2, len(neighbour_coord))
+
+    def test_three_by_three_board_neighbours(self):
+        b = board.Board((3,3))
+
+        target_coord = (1,1)
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=True))
+        self.assertEqual(8, len(neighbour_coord))
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=False))
+        self.assertEqual(4, len(neighbour_coord))
+
+        target_coord = (0,0)
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=True))
+        self.assertEqual(3, len(neighbour_coord))
+        neighbour_coord = list(b.neighbours(target_coord, include_diagonals=False))
+        self.assertEqual(2, len(neighbour_coord))

--- a/test_neighbour_board.py
+++ b/test_neighbour_board.py
@@ -16,11 +16,14 @@ class TestBoard(TestCase):
 
     def test_two_by_two_board_neighbours(self):
         b = board.Board((2, 2))
-        target_coord = (0,0)
+        target_coord = (0, 0)
         neighbour_coord = list(b.neighbours(target_coord, include_diagonals=True))
         self.assertEqual(3, len(neighbour_coord))
+        self.assertSetEqual({(0, 1), (1, 0), (1, 1)}, set(neighbour_coord))
+
         neighbour_coord = list(b.neighbours(target_coord, include_diagonals=False))
         self.assertEqual(2, len(neighbour_coord))
+        self.assertSetEqual({(0, 1), (1, 0)}, set(neighbour_coord))
 
     def test_three_by_three_board_neighbours(self):
         b = board.Board((3,3))

--- a/test_neighbour_board.py
+++ b/test_neighbour_board.py
@@ -4,15 +4,20 @@ import board
 class TestBoard(TestCase):
     def test_neighbours_original(self):
         b1 = board.Board((3, 3, 3))
-        neighbours = list(b1.neighbours((0, 0, 0), include_diagonals=False))
 
-        for coord in neighbours:
+        neighbour_coord = list(b1.neighbours((0,0,0), include_diagonals=True))
+        self.assertEqual(7, len(neighbour_coord))
+        self.assertSetEqual({(0, 1, 0), (1, 1, 0), (1, 0, 0),
+                             (0, 0, 1), (0, 1, 1), (1, 1, 1), (1, 0, 1)}, set(neighbour_coord))
+
+        neighbour_coord = list(b1.neighbours((0, 0, 0), include_diagonals=False))
+        for coord in neighbour_coord:
             print(coord)
-        self.assertEqual(3, len(neighbours))
+        #self.skipTest("diagonals seems to be producing wrong answer.")
+        self.assertEqual(3, len(neighbour_coord))
+        self.assertSetEqual({(0, 1, 0), (1, 0, 0),
+                             (0, 0, 1)}, set(neighbour_coord))
 
-
-        neighbours = list(b1.neighbours((0,0,0), include_diagonals=True))
-        self.assertEqual(7, len(neighbours))
 
     def test_two_by_two_board_neighbours(self):
         b = board.Board((2, 2))


### PR DESCRIPTION
I added additional test cases for include_diagonals=False.  I revised the neighbours method because my tests indicated that it was not giving me expected results for dimensions greater than 2.  Please let me know if these are reasonable or I'm missing something in the diagonals algorithm.