### PR TITLE
Neighbors within radius

### DIFF
--- a/test.py
+++ b/test.py
@@ -797,11 +797,43 @@ class BoardNeighbours(BoardTest):
         actual = set(b.neighbours(coord))
         self.assertEqual(expected, actual)
 
+    def test_neighbours_1d_center_radius_2(self):
+        """
+        Really small 1 dimension board still has neighbours.
+        """
+        b = Board(dimension_sizes=(5,))
+        coord = (2,)
+        expected = {(0,), (1,), (3,), (4,)}
+        actual = set(b.neighbours(coord, radius=2))
+        self.assertEqual(expected, actual)
+
     def test_neighbours_1d_center_no_diagonals(self):
         b = Board(dimension_sizes=(3,))
         coord = (1,)
         expected = {(0,), (2,)}
         actual = set(b.neighbours(coord, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
+    def test_neighbours_1d_center_no_diagonals_radius(self):
+        b = Board(dimension_sizes=(5,))
+        coord = (2,)
+        expected = {(1,), (3,)}
+        actual = set(b.neighbours(coord, radius=1, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
+        expected = {(0,), (1,), (3,), (4,)}
+        actual = set(b.neighbours(coord, radius=2, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
+    def test_neighbours_1d_side_no_diagonals_radius(self):
+        b = Board(dimension_sizes=(5,))
+        coord = (0,)
+        expected = {(1,)}
+        actual = set(b.neighbours(coord, radius=1, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
+        expected = {(1,),(2,)}
+        actual = set(b.neighbours(coord, radius=2, include_diagonals=False))
         self.assertEqual(expected, actual)
 
     def test_neighbours_2d_corner(self):
@@ -814,6 +846,11 @@ class BoardNeighbours(BoardTest):
         actual = set(b.neighbours(coord))
         self.assertEqual(expected, actual)
 
+        coord = (0, 0)
+        expected = {(1, 0), (2, 0), (0, 1), (0, 2), (2, 1), (1, 2), (1, 1), (2, 2)}
+        actual = set(b.neighbours(coord, radius=2))
+        self.assertEqual(expected, actual)
+
     def test_neighbours_2d_corner_exclude_diagonals(self):
         """Find neighbours when the anchor is at the corner of a 2d board
         """
@@ -824,6 +861,11 @@ class BoardNeighbours(BoardTest):
         actual = set(b.neighbours(coord, include_diagonals=False))
         self.assertEqual(expected, actual)
 
+        coord = (0, 0)
+        expected = {(1, 0), (2, 0), (0, 1), (0, 2)}
+        actual = set(b.neighbours(coord, radius=2, include_diagonals=False))
+        self.assertEqual(expected, actual)
+
     def test_neighbours_2d_centre(self):
         """Find neighbours when the anchor is not at the corner of a 2d board
         """
@@ -832,10 +874,20 @@ class BoardNeighbours(BoardTest):
         coord = (1, 1)
         expected = {
             (0, 0), (1, 0), (2, 0),
-            (0, 1), (2, 1),
+            (0, 1),         (2, 1),
             (0, 2), (1, 2), (2, 2)
         }
-        actual = set(b.neighbours((1, 1)))
+        actual = set(b.neighbours(coord=coord))
+        self.assertEqual(expected, actual)
+
+        coord = (1, 1)
+        expected = {
+            (0, 0), (1, 0), (2, 0), (3, 0),
+            (0, 1),         (2, 1), (3, 1),
+            (0, 2), (1, 2), (2, 2), (3, 2),
+            (0, 3), (1, 3), (2, 3), (3, 3)
+        }
+        actual = set(b.neighbours(coord=coord, radius=2))
         self.assertEqual(expected, actual)
 
     def test_neighbours_2d_centre_exclude_diagonals(self):
@@ -850,6 +902,15 @@ class BoardNeighbours(BoardTest):
                     (1, 2)
         }
         actual = set(b.neighbours((1, 1), include_diagonals=False))
+        self.assertEqual(expected, actual)
+
+        expected = {
+                    (1, 0),
+            (0, 1),         (2, 1), (3, 1),
+                    (1, 2),
+                    (1, 3),
+        }
+        actual = set(b.neighbours((1, 1), radius=2, include_diagonals=False))
         self.assertEqual(expected, actual)
 
     def test_neighbours_3d_corner(self):
@@ -891,6 +952,7 @@ class BoardNeighbours(BoardTest):
 
         actual = set(b.neighbours((1, 1, 1)))
         self.assertEqual(expected, actual)
+
 
     def test_neighbours_3d_centre_exclude_diagonals(self):
         """Find neighbours when the anchor is not at the corner of a 3d board

--- a/test_neighbour_board.py
+++ b/test_neighbour_board.py
@@ -45,3 +45,32 @@ class TestBoard(TestCase):
         self.assertEqual(3, len(neighbour_coord))
         neighbour_coord = list(b.neighbours(target_coord, include_diagonals=False))
         self.assertEqual(2, len(neighbour_coord))
+
+    def test_big_board_radius(self):
+        b = board.Board((32, 64))
+        target_coord = (10, 10)
+        neighbour_coord = list(b.neighbours(target_coord, radius=3, include_diagonals=True))
+        self.assertEqual(7*7-1, len(neighbour_coord))
+
+        target_coord = (0, 0)
+        neighbour_coord = list(b.neighbours(target_coord, radius=3, include_diagonals=True))
+        self.assertEqual(4*4-1, len(neighbour_coord))
+
+        target_coord = (31, 63)
+        neighbour_coord = list(b.neighbours(target_coord, radius=3, include_diagonals=True))
+        self.assertEqual(4*4-1, len(neighbour_coord))
+
+    def test_big_board_radius(self):
+        b = board.Board((13,13))
+        target_coord = (5, 5)
+        b[target_coord] = "C"
+        for coord in b.neighbours(target_coord, radius=3, include_diagonals=True):
+            b[coord] = "N"
+        b.draw()
+
+        b = board.Board((13, 13))
+        target_coord = (5, 5)
+        b[target_coord] = "C"
+        for coord in b.neighbours(target_coord, radius=3, include_diagonals=False):
+            b[coord] = "N"
+        b.draw()

--- a/test_neighbour_board.py
+++ b/test_neighbour_board.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import board
 
 class TestBoard(TestCase):
+
     def test_neighbours_original(self):
         b1 = board.Board((3, 3, 3))
 


### PR DESCRIPTION
I'm going to need more than just one neighbor away.  For example, is X within two cells of Y?  


I thought I would call this radius and the original implementation assumes radius of 1.  (offsets ±1). 

```
+-+-+-+-+-+-+-+
| | | | | | | |
+-+-+-+-+-+-+-+
| | | | | | | |
+-+-+-+-+-+-+-+
| | |N|N|N| | |
+-+-+-+-+-+-+-+
| | |N|C|N| | |
+-+-+-+-+-+-+-+
| | |N|N|N| | |
+-+-+-+-+-+-+-+
| | | | | | | |
+-+-+-+-+-+-+-+
| | | | | | | |
+-+-+-+-+-+-+-+
```

I can use radius to find offsets ±2, etc..  

```
+-+-+-+-+-+-+-+ 
| | | | | | | | 
+-+-+-+-+-+-+-+ 
| |N|N|N|N|N| | 
+-+-+-+-+-+-+-+ 
| |N|N|N|N|N| | 
+-+-+-+-+-+-+-+ 
| |N|N|C|N|N| | 
+-+-+-+-+-+-+-+ 
| |N|N|N|N|N| | 
+-+-+-+-+-+-+-+ 
| |N|N|N|N|N| | 
+-+-+-+-+-+-+-+ 
| | | | | | | | 
+-+-+-+-+-+-+-+ 
```
Also include_diagonals=False case and came up with a calculation without having to filter to exclude overshoot.

```
+-+-+-+-+-+-+-+ 
| | | | | | | | 
+-+-+-+-+-+-+-+ 
| | | |N| | | | 
+-+-+-+-+-+-+-+ 
| | | |N| | | | 
+-+-+-+-+-+-+-+ 
| |N|N|C|N|N| | 
+-+-+-+-+-+-+-+ 
| | | |N| | | | 
+-+-+-+-+-+-+-+ 
| | | |N| | | | 
+-+-+-+-+-+-+-+ 
| | | | | | | | 
+-+-+-+-+-+-+-+ 
```


Some performance metrics:

neighbours_old include diagonals 11.325730125
neighbours_new include diagonals 11.859233042

neighbours_old no diagonals 9.099551541999997
neighbours_new no diagonals 7.889327375000001

Slightly worse on include_diagonals=True but significantly better on include_diagonals=False

All tests pass and added tests for larger radii.